### PR TITLE
Enhancement - Remove clip path on drag end

### DIFF
--- a/app/src/main/java/com/vivek/bodyscan/ui/components/ScanningCanvas.kt
+++ b/app/src/main/java/com/vivek/bodyscan/ui/components/ScanningCanvas.kt
@@ -46,12 +46,10 @@ fun ScanningCanvas(
             .padding(4.dp)
             .pointerInput(Unit) {
                 detectDragGestures(
-                    onDragStart = { offset ->
-                        scannedOffset = offset
+                    onDragStart = {
                         circleRadius = 300f
                     },
                     onDragEnd = {
-                        scannedOffset = Offset.Zero
                         circleRadius = 0f
                     }
                 ) { change, _ ->

--- a/app/src/main/java/com/vivek/bodyscan/ui/components/ScanningCanvas.kt
+++ b/app/src/main/java/com/vivek/bodyscan/ui/components/ScanningCanvas.kt
@@ -37,6 +37,7 @@ fun ScanningCanvas(
     modifier: Modifier
 ) {
     var scannedOffset by remember { mutableStateOf(Offset(-500f, -500f)) }
+    var circleRadius by remember { mutableStateOf(300f) }
 
     Canvas(
         modifier = modifier
@@ -44,7 +45,16 @@ fun ScanningCanvas(
             .background(OverlayScreenBGColor)
             .padding(4.dp)
             .pointerInput(Unit) {
-                detectDragGestures { change, _ ->
+                detectDragGestures(
+                    onDragStart = { offset ->
+                        scannedOffset = offset
+                        circleRadius = 300f
+                    },
+                    onDragEnd = {
+                        scannedOffset = Offset.Zero
+                        circleRadius = 0f
+                    }
+                ) { change, _ ->
                     scannedOffset = change.position
                 }
             }
@@ -56,7 +66,7 @@ fun ScanningCanvas(
         val canvasHeight = size.height
 
         val circle = Path().apply {
-            addOval(oval = Rect(scannedOffset, 300f))
+            addOval(oval = Rect(scannedOffset, circleRadius))
         }
 
         // Overlay Image


### PR DESCRIPTION
### ✍️  Existing behaviour
Whenever the user drags on the screen, the internal body part is shown. But when the user stops the drag, the clipped circle path stays on the screen. 

### 💡 Suggested Feature
When the user stops dragging on the screen, the clipped path is removed and the original body image is shown.

### 📝 Changes
In the `detectDragGestures` method, the `scannedOffset` and `circleRadius` properties have been set accordingly. 

 